### PR TITLE
Remove popularity boost

### DIFF
--- a/lib/stops.js
+++ b/lib/stops.js
@@ -95,9 +95,6 @@ function loadGtfsStops(filePath, agencyId, agencyName, layerId, layerName) {
 
       //doc.addCategory('transit category');
 
-      // TODO: maybe set popularity via the config
-      doc.setPopularity(100000);
-
       this.push(doc);
       callback();
   }));


### PR DESCRIPTION
Once we've worked on the functionality for https://github.com/OpenTransitTools/trimet-mod-pelias/issues/7, this will no longer be needed.