### PR TITLE
Support read-only root fs when running in Docker containers

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec node lib/prep_data.js

--- a/bin/start
+++ b/bin/start
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec node index.js

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Import Stops, Intersections, P&Rs, TCs, TVMs and other landmark data related to transit, etc...",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js",
+    "start": "./bin/start",
     "test": "./bin/test",
     "download": "node lib/prep_data.js",
     "lint": "jshint .",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "./bin/start",
     "test": "./bin/test",
-    "download": "node lib/prep_data.js",
+    "download": "./bin/download",
     "lint": "jshint .",
     "travis": "npm test",
     "validate": "npm ls"


### PR DESCRIPTION
By using a dedicated start and download script instead of `npm start` and `npm run download` when running Docker images, we can avoid issues with passing signals through to the underlying processes.

This also avoids issues with `npm` requiring write permissions to the root filesystem.

Connects https://github.com/pelias/pelias/issues/745