### PR TITLE
feat(config): warn instead of error when transit not configured

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -130,8 +130,7 @@ function getTransitConfig() {
     process.exit(0);
   }
   if(transitConfig === undefined) {
-    logger.error(peliasConfig);
-    logger.error(`your 'pelias.json' config lacks a transit object entry ... @see schema.js`);
+    logger.warn(`'pelias.json' config lacks a transit object entry. Transit importer quitting after taking no action`);
     process.exit(0);
   }
 


### PR DESCRIPTION
In the case where there's no transit object in `pelias.json`, a large error including the entire contents of `pelias.json` is currently thrown.

This changes that to a much less scary warning.

Connects https://github.com/pelias/docker/issues/5