### PR TITLE
feat(download): Use friendly warnings when Transit config is empty

### DIFF
--- a/lib/prep_data.js
+++ b/lib/prep_data.js
@@ -4,12 +4,18 @@ const path = require('path');
 const request = require('sync-request');
 const utils = require('./utils');
 const stops = require('./stops');
+const logger = require( 'pelias-logger' ).get('transit');
 
 const BUF_LENGTH = 64*1024;
 
 // step 1: get transit configuration from pelias.json ... note potential early process exit
 const transitConfig = utils.getTransitConfig();
 const bkupDir = path.join(transitConfig.datapath, 'backup');
+
+if (!transitConfig.feeds) {
+  logger.warn('transit config has no `feed` entries, Transit importer quitting after taking no action');
+  process.exit(0);
+}
 
 // step 2: make sure (as best as we can) we have a directory to write things into
 mkdir(transitConfig.datapath);

--- a/schema.js
+++ b/schema.js
@@ -33,5 +33,5 @@ const arrayObj = Joi.object().keys({
 */
 module.exports = Joi.object().keys({
   datapath: Joi.string(),
-  feeds: Joi.array().min(1).items(arrayObj),
-}).requiredKeys('datapath', 'feeds');
+  feeds: Joi.array().items(arrayObj)
+}).requiredKeys('datapath');


### PR DESCRIPTION
This loosens the validation on the transit config entry, and handles the case when the `feeds` property is missing. Often, the transit importer is not configured in a Pelias project, and the previous alarming warnings were excessive.

Connects https://github.com/pelias/docker/issues/5