### PR TITLE
feat(name): Trim extra spaces from stop names

### DIFF
--- a/lib/stops.js
+++ b/lib/stops.js
@@ -59,6 +59,8 @@ function loadGtfsStops(filePath, agencyId, agencyName, layerId, layerName) {
         name = rec.stop_desc;
       }
 
+      name = name.trim();
+
       // stop code (alt name) ... appended to name if not in there
       var altName = null;
       if(rec.stop_code && rec.stop_code.length > 0 && rec.stop_code !== 'null'){


### PR DESCRIPTION
Some Transit entries often include extra whitespace. The whitespace won't make a difference for most end users, but it does make it harder to compare results in tests.

This PR trims whitespace from the `name` field of all stop records.