### PR TITLE
improved string deduplication between name and altname

### DIFF
--- a/lib/stops.js
+++ b/lib/stops.js
@@ -112,7 +112,9 @@ function generateName(rec, agencyName, layerName){
     var agency = util.format('%s Stop', agencyName);
 
     // formatting including the altname
-    if( !_.isEmpty(altname) && !_.includes(name, altname) ){
+    // note: we pad both strings with spaces to enfore 'phrase matching',
+    // avoiding substring matches.
+    if( !_.isEmpty(altname) && !_.includes(util.format(' %s ', name), util.format(' %s ', altname)) ){
       name = util.format('%s (%s ID %s)', name, agency, altname);
 
     // without the alt name

--- a/test/lib/stops.js
+++ b/test/lib/stops.js
@@ -111,6 +111,32 @@ module.exports.tests.generateName = function(test, common) {
     t.equals(actual, 'test (Acme Stop)');
     t.end();
   });
+
+  // altname
+  test('generateName: altname included', function(t) {
+    var actual = stops.generateName({
+      stop_name: 'Stop Name',
+      stop_code: 'Alt Name'
+    }, 'Acme');
+    t.equals(actual, 'Stop Name (Acme Stop ID Alt Name)');
+    t.end();
+  });
+  test('generateName: altname not included if duplicate of name', function(t) {
+    var actual = stops.generateName({
+      stop_name: 'Testing 123',
+      stop_code: 'Testing 123'
+    }, 'Acme');
+    t.equals(actual, 'Testing 123 (Acme Stop)');
+    t.end();
+  });
+  test('generateName: altname not included if duplicate of name - complex case', function(t) {
+    var actual = stops.generateName({
+      stop_name: '23300 Block NE Halsey',
+      stop_code: '2330'
+    }, 'Acme');
+    t.equals(actual, '23300 Block NE Halsey (Acme Stop ID 2330)');
+    t.end();
+  });
 };
 
 module.exports.all = function (tape, common) {


### PR DESCRIPTION
I noticed this case where the altname was being omitted incorrectly:

```
-            "name": "23300 Block NE Halsey (TriMet Stop ID 2330)"
+            "name": "23300 Block NE Halsey (TriMet Stop)"
```

This was because `2330` is a substring of `23300 Block NE Halsey`.

The new logic will not match **within** tokens, only whole tokens as per 'phrase matching'