### PR TITLE
feat(logger): Use dbclient name functionality

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -63,7 +63,7 @@ function loadTransitFeeds(transitConfig) {
   recordStream
     .pipe(adminLookupStream.create())
     .pipe(model.createDocumentMapperStream())
-    .pipe(dbclient());
+    .pipe(dbclient({name: 'transit'}));
 }
 
 module.exports.loadTransitFeeds = loadTransitFeeds;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "joi": "^11.0.1",
     "lodash": "^4.16.0",
     "pelias-config": "^2.12.1",
-    "pelias-dbclient": "^2.2.2",
+    "pelias-dbclient": "^2.8.0",
     "pelias-logger": "^0.2.0",
     "pelias-model": "^5.4.0",
     "pelias-wof-admin-lookup": "^4.6.5",


### PR DESCRIPTION
This allows distinguishing which logger output lines correspond to which
importer during an import.

Connects https://github.com/pelias/dbclient/issues/101
