### PR TITLE
update npm dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,21 +15,22 @@
   "attribution": "code based off of Delaware Schools from trescube https://github.com/trescube/delaware-schools-pelias-importer, as well as other Pelias loader projects",
   "license": "MPL-2.0",
   "dependencies": {
+    "@hapi/joi": "^16.1.0",
     "JSONStream": "^1.3.1",
     "combined-stream": "1.0.8",
     "csv-parse": "^4.4.5",
     "decompress": "^4.0.0",
-    "@hapi/joi": "^16.1.0",
     "lodash": "^4.16.0",
-    "pelias-config": "^4.1.0",
-    "pelias-dbclient": "^2.8.0",
+    "pelias-config": "^4.5.0",
+    "pelias-dbclient": "^2.13.0",
     "pelias-logger": "^1.4.1",
-    "pelias-model": "^7.0.0",
+    "pelias-model": "^7.1.0",
     "pelias-wof-admin-lookup": "^5.3.0",
     "sync-request": "^6.1.0",
     "through2": "^3.0.1"
   },
   "devDependencies": {
+    "jshint": "^2.10.3",
     "precommit-hook": "^3.0.0",
     "tap-spec": "^5.0.0",
     "tape": "^4.9.1"


### PR DESCRIPTION
update `npm` dependencies.

In particular I would like to bring in the changes from:
- "pelias-config": "^4.5.0"
- "pelias-dbclient": "^2.13.0"
- "pelias-model": "^7.1.0"

I also noticed that `jshint` was being called in the precommit hook but the module wasn't listed in `package.json`

> .git/hooks/pre-commit: line 243: jshint: command not found

Any other updates are a bonus :tada: