### PR TITLE
remove agency aliases from name.default field

### DIFF
--- a/lib/stops.js
+++ b/lib/stops.js
@@ -51,35 +51,31 @@ function loadGtfsStops(filePath, agencyId, agencyName, layerId, layerName) {
       columns: true
     }))
     .pipe(through.obj(isStop))
-    .pipe(through.obj(function(rec, _, callback) {
-      
-      // generate document ID
-      const id = utils.makeTransitId(rec.stop_id, agencyId, LAYER_ID);
+    .pipe(through.obj(generateRecordXform(agencyId, agencyName, layerName)));
+}
 
-      // generate the document name
-      var name = generateName(rec, agencyName, layerName);
+// generate pelias document
+function generateRecordXform(agencyId, agencyName, layerName) {
+  return (rec, _, next) => {
 
-      // create a pelias/model document
-      var doc = utils.makePeliasRecord(LAYER_ID, id, name, rec.stop_lat, rec.stop_lon);
+    // generate document ID
+    const id = utils.makeTransitId(rec.stop_id, agencyId, LAYER_ID);
 
-      // set some aliases
-      if(rec.stop_code && rec.stop_code.length > 0){
-        doc.setNameAlias('default', rec.stop_code);
-        doc.setNameAlias('default', util.format('Stop %s', rec.stop_code));
-        doc.setNameAlias('default', util.format('%s stop', rec.stop_code));
-      }
-      if(agencyName){
-        doc.setNameAlias('default', agencyName);
-      }
-      if(agencyId){
-        doc.setNameAlias('default', agencyId);
-      }
+    // generate the document name
+    const name = generateName(rec, agencyName, layerName);
 
-      //doc.addCategory('transit category');
+    // create a pelias/model document
+    const doc = utils.makePeliasRecord(LAYER_ID, id, name, rec.stop_lat, rec.stop_lon);
 
-      this.push(doc);
-      callback();
-  }));
+    // set some aliases
+    if (rec.stop_code && rec.stop_code.length > 0) {
+      doc.setNameAlias('default', rec.stop_code);
+      doc.setNameAlias('default', util.format('Stop %s', rec.stop_code));
+      doc.setNameAlias('default', util.format('%s stop', rec.stop_code));
+    }
+
+    next(null, doc);
+  };
 }
 
 // generate the document name
@@ -90,11 +86,11 @@ function generateName(rec, agencyName, layerName){
   if( !_.isString(agencyName) ){ throw new Error( 'invalid agency name' ); }
   if( _.isEmpty(agencyName) ){ throw new Error( 'invalid agency name' ); }
   if( !_.isString(layerName) ){ layerName = ''; }
-  
+
   // stop name and alternative name
   var name = '';
   var altname = '';
-  
+
   // select which field to use for the name
   if( _.isString( rec.stop_name ) && rec.stop_name !== 'null' ) {
     name = rec.stop_name.trim();
@@ -150,5 +146,6 @@ function unzipStopsFromGtfs(feedZip, outDir, outFileName) {
 module.exports = {
   loadGtfsStops : loadGtfsStops,
   unzipStopsFromGtfs : unzipStopsFromGtfs,
-  generateName : generateName
+  generateName : generateName,
+  generateRecordXform : generateRecordXform
 };

--- a/test/lib/stops.js
+++ b/test/lib/stops.js
@@ -1,5 +1,6 @@
 
 const stops = require('../../lib/stops');
+const model = require('pelias-model');
 module.exports.tests = {};
 
 // test exports
@@ -136,6 +137,29 @@ module.exports.tests.generateName = function(test, common) {
     }, 'Acme');
     t.equals(actual, '23300 Block NE Halsey (Acme Stop ID 2330)');
     t.end();
+  });
+};
+
+module.exports.tests.generateRecordXform = (test) => {
+  test('generateRecordXform: do not set agencyName or agencyId as name aliases', t => {
+    const func = stops.generateRecordXform('example_agency_id', 'example_agency_name', 'example_layer_name');
+    const rec = {
+      stop_id: 'example_stop_id',
+      stop_code: 'example_stop_code',
+      stop_lat: 1.1,
+      stop_lon: 2.2
+    };
+    func(rec, undefined, (err, doc) => {
+      t.false(err);
+      t.true(doc instanceof model.Document, 'instance of pelias model');
+      t.deepEquals(doc.name.default, [
+        'example_agency_name example_layer_name',
+        'example_stop_code',
+        'Stop example_stop_code',
+        'example_stop_code stop'
+      ]);
+      t.end();
+    });
   });
 };
 


### PR DESCRIPTION
this draft PR is to test the effects of removing the `agencyName` and `agencyId` from `name.default` aliases

note: I wrote this code quickly so it could do with cleanup before it's published