### PR TITLE
Require >= pelias-config-4.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "csv-parse": "^4.4.5",
     "decompress": "^4.0.0",
     "lodash": "^4.16.0",
-    "pelias-config": "^4.5.0",
+    "pelias-config": "^4.8.0",
     "pelias-dbclient": "^2.13.0",
     "pelias-logger": "^1.4.1",
     "pelias-model": "^7.1.0",


### PR DESCRIPTION
As of `pelias-config-4.8.0` we are now using the new Elasticsearch 7 compatible default document type name: `_doc`.

Now that we have dropped support for ES5, we want to ensure this value is the default going forward.

Connects https://github.com/pelias/config/pull/122
Connects https://github.com/pelias/pelias/issues/831