### PR TITLE
chore(TravisCI): Remove deprecated `matrix` config section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ notifications:
   email: false
 node_js:
   - 10
-matrix:
-  fast_finish: true
 script: ./bin/test
 before_install:
   - npm i -g npm


### PR DESCRIPTION
This config entry is deprecated, and has now started overwriting the `jobs` section, causing build issues.

Connects pelias/pelias#850