### PR TITLE
Add .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+node_modules


### PR DESCRIPTION
This file helps reduce errors in our Docker builds, primarily by ensuring the local `node_modules` directory is not used when building the Docker image.

Connects https://github.com/pelias/transit/issues/42