### PR TITLE
Upgrade to wof-admin-lookup 7.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,16 +16,16 @@
   "license": "MPL-2.0",
   "dependencies": {
     "@hapi/joi": "^16.1.0",
-    "JSONStream": "^1.3.1",
     "combined-stream": "1.0.8",
     "csv-parse": "^4.4.5",
     "decompress": "^4.0.0",
+    "JSONStream": "^1.3.1",
     "lodash": "^4.16.0",
     "pelias-config": "^4.8.0",
     "pelias-dbclient": "^2.13.0",
     "pelias-logger": "^1.4.1",
     "pelias-model": "^7.1.0",
-    "pelias-wof-admin-lookup": "^7.0.0",
+    "pelias-wof-admin-lookup": "^7.7.0",
     "sync-request": "^6.1.0",
     "through2": "^3.0.1"
   },


### PR DESCRIPTION
This includes the changes in https://github.com/pelias/wof-admin-lookup/pull/311 that help with using the `boundary.country` API parameter with `dependency` placetypes.