### PR TITLE
feat(es8): support elasticsearch v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "decompress": "^4.0.0",
     "JSONStream": "^1.3.1",
     "lodash": "^4.16.0",
-    "pelias-config": "^4.8.0",
-    "pelias-dbclient": "^2.13.0",
+    "pelias-config": "^6.0.0",
+    "pelias-dbclient": "^3.0.0",
     "pelias-logger": "^1.4.1",
-    "pelias-model": "^7.1.0",
+    "pelias-model": "^10.0.0",
     "pelias-wof-admin-lookup": "^7.7.0",
     "sync-request": "^6.1.0",
     "through2": "^3.0.1"


### PR DESCRIPTION
this PR modifies the importer such that it works for both elasticsearch v7 & v8
in order to support v8 this PR drops support for v6.