### PR TITLE
Upgrade pelias-wof-admin-lookup to v7.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "pelias-dbclient": "^3.1.0",
     "pelias-logger": "^1.4.1",
     "pelias-model": "^10.0.0",
-    "pelias-wof-admin-lookup": "^7.11.0",
+    "pelias-wof-admin-lookup": "^7.12.0",
     "sync-request": "^6.1.0",
     "through2": "^3.0.1"
   },


### PR DESCRIPTION
Includes a fix for macroregions/region ordering from https://github.com/pelias/wof-admin-lookup/pull/325